### PR TITLE
Fixed a couple of problems in preventDuplicates

### DIFF
--- a/src/vue-toastr.js
+++ b/src/vue-toastr.js
@@ -75,8 +75,8 @@ export default {
             if (data.preventDuplicates) {
                 var listKeys = Object.keys(this.list[data.position]);
                 for (var i = 0; i < listKeys.length; i++) {
-                    if (this.list[data.position].title === data.title && this.list[data.position].msg === data.msg) {
-                        console.log('Prevent Dublicates', data)
+                    if (this.list[data.position][listKeys[i]].title === data.title && this.list[data.position][listKeys[i]].msg === data.msg) {
+                        console.log('Prevent Duplicates', data)
                         return false
                     }
                 }
@@ -122,7 +122,8 @@ export default {
                 timeout: this.defaultTimeout,
                 closeOnHover: this.defaultCloseOnHover,
                 progressbar: this.defaultProgressBar,
-                progressBarValue: this.defaultProgressBarValue
+                progressBarValue: this.defaultProgressBarValue,
+                preventDuplicates: this.defaultPreventDuplicates
             }
         },
         e(msg, title) {


### PR DESCRIPTION
The duplicate prevention functionality was broken.

Fixed a couple of problems:

1. Accessing object properties where searching for duplicates: _this.list[data.position].title_ should be _this.list[data.position][listKeys[i]].title_

2. Missing preventDuplicates initialization if toastr called with string parameters